### PR TITLE
Automatically detect a literate coffee file

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = function(source) {
 	var coffeeRequest = loaderUtils.getRemainingRequest(this);
 	var jsRequest = loaderUtils.getCurrentRequest(this);
 	var result = coffee.compile(source, {
+		literate: /\.(litcoffee|coffee\.md)$/.test(coffeeRequest),
 		filename: coffeeRequest,
 		debug: this.debug,
 		bare: true,


### PR DESCRIPTION
The CoffeeScript compiler does this auto-detection when acting on a file directly, but it is necessary to tell the compiler if a source string is literate CoffeeScript.
