### PR TITLE
Report line and offending character on errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,15 +8,32 @@ module.exports = function(source) {
 	this.cacheable && this.cacheable();
 	var coffeeRequest = loaderUtils.getRemainingRequest(this);
 	var jsRequest = loaderUtils.getCurrentRequest(this);
-	var result = coffee.compile(source, {
-		filename: coffeeRequest,
-		debug: this.debug,
-		bare: true,
-		sourceMap: true,
-		sourceRoot: "",
-		sourceFiles: [coffeeRequest],
-		generatedFile: jsRequest
-	});
+	var result;
+	try {
+		result = coffee.compile(source, {
+			filename: coffeeRequest,
+			debug: this.debug,
+			bare: true,
+			sourceMap: true,
+			sourceRoot: "",
+			sourceFiles: [coffeeRequest],
+			generatedFile: jsRequest
+		});
+	} catch (e) {
+		var err = "";
+		if (e.location == null || e.location.first_column == null || e.location.first_line == null) {
+			err += "Got an unexpected exception from the coffee-script compiler. The original exception was: " + e + "\n";
+			err += "(The coffee-script compiler should not raise *unexpected* exceptions. You can file this error as an issue of the coffee-script compiler: https://github.com/jashkenas/coffee-script/issues)\n";
+		} else {
+			var codeLine = source.split("\n")[e.location.first_line];
+			var offendingCharacter = (e.location.first_column < codeLine.length) ? codeLine[e.location.first_column] : "";
+			err += e + "\n";
+			// log erroneous line and highlight offending character
+			err += "    L" + e.location.first_line + ": " + codeLine.substring(0, e.location.first_column) + offendingCharacter + codeLine.substring(e.location.first_column + 1) + "\n";
+			err += "         " + (new Array(e.location.first_column + 1).join(" ")) + "^\n";
+		}
+		throw new Error(err);
+	}
 	var map = JSON.parse(result.v3SourceMap);
 	map.sourcesContent = [source];
 	this.callback(null, result.js, map);


### PR DESCRIPTION
This will respond with the following output upon an error:

``` shell
$ grunt webpack:dist
Running "webpack:dist" (webpack) task

Running "actualWebpack:dist" (actualWebpack) task
Version: webpack 1.1.8      
Asset  Size  Chunks       Chunk Names

ERROR in ./src/index.coffee
Module build failed: Error: SyntaxError: unexpected WHEN
    L15: require ['./app'], (App) -> App.create() when if that
                                                  ^

    at Object.module.exports (/Users/Kyle/Documents/www/coffee-loader/index.js:37:9)
Warning: Task "actualWebpack:dist" failed. Use --force to continue.
Error: Task "actualWebpack:dist" failed.
    at Task.<anonymous> (/Users/Kyle/Documents/www/ynab/ynab_web/node_modules/grunt/lib/util/task.js:200:15)
    at null._onTimeout (/Users/Kyle/Documents/www/ynab/ynab_web/node_modules/grunt/lib/util/task.js:236:33)
    at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)

Aborted due to warnings.
```

Fixes GH-5. Cheers!
