### PR TITLE
Normalize sourceRoot values to null

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function(source) {
 			debug: this.debug,
 			bare: true,
 			sourceMap: true,
-			sourceRoot: "",
+			sourceRoot: null,
 			sourceFiles: [coffeeRequest],
 			generatedFile: jsRequest
 		});
@@ -38,6 +38,11 @@ module.exports = function(source) {
 	}
 	var map = JSON.parse(result.v3SourceMap);
 	map.sourcesContent = [source];
+	if (map.sourceRoot === "") {
+		// source-map >=0.1.35 will convert sourceFile values to relative
+		// paths if `sourceRoot` is non-null
+		map.sourceRoot = null;
+	}
 	this.callback(null, result.js, map);
 }
 module.exports.seperable = true;


### PR DESCRIPTION
source-map>=0.1.35 will convert source paths to relative paths if sourceRoot is non-null (including the empty string). The coffee script compiler may return `sourceRoot` values that are the empty string, rather than null.

This gets webpack tests passing with source-map@0.1.35 and up and is a prerequisite for webpack/core#5.
