### PR TITLE
Fix coffee-script dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"loader-utils": "^1.0.2"
 	},
 	"peerDependencies": {
-		"coffee-script": "1.x"
+		"coffee-script": "^1.6.0"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
`coffee-loader` uses `v3SourceMap`, which was introduced in `coffee-script@1.6.0`, so this makes that dependency explicit. This was broken in projects that already had a dependency on `coffee-script >1.0 <= 1.6.0`, since that met the peer dependency, yet threw errors on compile.