### PR TITLE
FIX toggle sourceMaps based on provided options

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright JS Foundation and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 ## Usage
 
 ``` javascript
-var exportsOfFile = require("coffee!./file.coffee");
+var exportsOfFile = require("coffee-loader!./file.coffee");
 // => return exports of executed and compiled file.coffee
 
-var exportsOfFile2 = require("coffee?literate!./file.litcoffee");
+var exportsOfFile2 = require("coffee-loader?literate!./file.litcoffee");
 // can also compile literate files.
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,151 @@
-# coffee-script loader for webpack
+[![npm][npm]][npm-url]
+[![node][node]][node-url]
+[![deps][deps]][deps-url]
+[![tests][tests]][tests-url]
+[![coverage][cover]][cover-url]
+[![chat][chat]][chat-url]
 
-## Usage
+<div align="center">
+  <img width="160" height="160"
+    src="https://cdn.worldvectorlogo.com/logos/coffeescript.svg">
+  <a href="https://github.com/webpack/webpack">
+    <img width="200" height="200" hspace="20"
+      src="https://webpack.js.org/assets/icon-square-big.svg">
+  </a>
+  <h1>Coffee Loader</h1>
+</div>
 
-``` javascript
-var exportsOfFile = require("coffee-loader!./file.coffee");
-// => return exports of executed and compiled file.coffee
+<h2 align="center">Install</h2>
 
-var exportsOfFile2 = require("coffee-loader?literate!./file.litcoffee");
-// can also compile literate files.
+```bash
+npm install --save-dev coffee-loader
 ```
 
-[Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
+<h2 align="center">Usage</h2>
 
-### Recommended configuration
 
-``` javascript
-{
-	module: {
-		loaders: [
-			{ test: /\.coffee$/, loader: "coffee-loader" },
-			{ test: /\.(coffee\.md|litcoffee)$/, loader: "coffee-loader?literate" }
-		]
-	}
+```js
+import coffee from 'coffee-loader!./file.coffee';
+```
+
+### Configuration (recommended)
+
+
+```js
+import coffee from 'file.coffee';
+```
+
+**webpack.config.js**
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.coffee$/,
+        use: [ 'coffee-loader' ]
+      }
+    ]
+  }
 }
 ```
 
-## License
+<h2 align="center">Options</h2>
 
-MIT (http://www.opensource.org/licenses/mit-license.php)
+|Name|Default|Description|
+|:--:|:-----:|:----------|
+|**`literate`**|`false`|Enable CoffeeScript in Markdown (Code Blocks) e.g `file.coffee.md`|
+|**`sourceMap`**|`false`|Enable/Disable Sourcemaps|
+
+### [Literate](http://coffeescript.org/#literate)
+
+**webpack.config.js**
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.coffee.md$/,
+        use: [
+          {
+            loader: 'coffee-loader',
+            options: { literate: true }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Sourcemaps
+
+**webpack.config.js**
+```js
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.coffee$/,
+        use: [
+          {
+            loader: 'coffee-loader',
+            options: { sourceMap: true }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+<h2 align="center">Maintainer</h2>
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/166921?v=3&s=150">
+        </br>
+        <a href="https://github.com/bebraw">Juho Vepsäläinen</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars2.githubusercontent.com/u/8420490?v=3&s=150">
+        </br>
+        <a href="https://github.com/d3viant0ne">Joshua Wiens</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/533616?v=3&s=150">
+        </br>
+        <a href="https://github.com/SpaceK33z">Kees Kluskens</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/3408176?v=3&s=150">
+        </br>
+        <a href="https://github.com/TheLarkInn">Sean Larkin</a>
+      </td>
+    </tr>
+  <tbody>
+</table>
+
+
+[npm]: https://img.shields.io/npm/v/coffee-loader.svg
+[npm-url]: https://npmjs.com/package/coffee-loader
+
+[node]: https://img.shields.io/node/v/coffee-loader.svg
+[node-url]: https://nodejs.org
+
+[deps]: https://david-dm.org/webpack/coffee-loader.svg
+[deps-url]: https://david-dm.org/webpack/coffee-loader
+
+[tests]: http://img.shields.io/travis/webpack/coffee-loader.svg
+[tests-url]: https://travis-ci.org/webpack/coffee-loader
+
+[cover]: https://coveralls.io/repos/github/webpack/coffee-loader/badge.svg
+[cover-url]: https://coveralls.io/github/webpack/coffee-loader
+
+[chat]: https://badges.gitter.im/webpack/webpack.svg
+[chat-url]: https://gitter.im/webpack/webpack

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
       src="https://webpack.js.org/assets/icon-square-big.svg">
   </a>
   <h1>Coffee Loader</h1>
+  <p>Loads <a href="http://coffeescript.org/">CoffeeScript</a> like JavaScript</p>
 </div>
 
 <h2 align="center">Install</h2>

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ var exportsOfFile = require("coffee!./file.coffee");
 // => return exports of executed and compiled file.coffee
 ```
 
-Don't forget to polyfill `require` if you want to use it in node.
-See `webpack` documentation.
+[Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,25 @@
 ``` javascript
 var exportsOfFile = require("coffee!./file.coffee");
 // => return exports of executed and compiled file.coffee
+
+var exportsOfFile2 = require("coffee?literate!./file.litcoffee");
+// can also compile literate files.
 ```
 
 [Documentation: Using loaders](http://webpack.github.io/docs/using-loaders.html)
+
+### Recommended configuration
+
+``` javascript
+{
+	module: {
+		loaders: [
+			{ test: /\.coffee$/, loader: "coffee-loader" },
+			{ test: /\.(coffee\.md|litcoffee)$/, loader: "coffee-loader?literate" }
+		]
+	}
+}
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ module.exports = {
 |Name|Default|Description|
 |:--:|:-----:|:----------|
 |**`literate`**|`false`|Enable CoffeeScript in Markdown (Code Blocks) e.g `file.coffee.md`|
-|**`sourceMap`**|`false`|Enable/Disable Sourcemaps|
+|**`sourceMap`**|`true`|Enable/Disable Sourcemaps|
 
 ### [Literate](http://coffeescript.org/#literate)
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@ module.exports = function(source) {
 	this.cacheable && this.cacheable();
 	var coffeeRequest = loaderUtils.getRemainingRequest(this);
 	var jsRequest = loaderUtils.getCurrentRequest(this);
+	var query = loaderUtils.parseQuery(this.query);
 	var result = coffee.compile(source, {
+		literate: query.literate,
 		filename: coffeeRequest,
 		debug: this.debug,
 		bare: true,

--- a/index.js
+++ b/index.js
@@ -9,16 +9,33 @@ module.exports = function(source) {
 	var coffeeRequest = loaderUtils.getRemainingRequest(this);
 	var jsRequest = loaderUtils.getCurrentRequest(this);
 	var query = loaderUtils.parseQuery(this.query);
-	var result = coffee.compile(source, {
-		literate: query.literate,
-		filename: coffeeRequest,
-		debug: this.debug,
-		bare: true,
-		sourceMap: true,
-		sourceRoot: "",
-		sourceFiles: [coffeeRequest],
-		generatedFile: jsRequest
-	});
+	var result;
+	try {
+		result = coffee.compile(source, {
+			literate: query.literate,
+			filename: coffeeRequest,
+			debug: this.debug,
+			bare: true,
+			sourceMap: true,
+			sourceRoot: "",
+			sourceFiles: [coffeeRequest],
+			generatedFile: jsRequest
+		});
+	} catch (e) {
+		var err = "";
+		if (e.location == null || e.location.first_column == null || e.location.first_line == null) {
+			err += "Got an unexpected exception from the coffee-script compiler. The original exception was: " + e + "\n";
+			err += "(The coffee-script compiler should not raise *unexpected* exceptions. You can file this error as an issue of the coffee-script compiler: https://github.com/jashkenas/coffee-script/issues)\n";
+		} else {
+			var codeLine = source.split("\n")[e.location.first_line];
+			var offendingCharacter = (e.location.first_column < codeLine.length) ? codeLine[e.location.first_column] : "";
+			err += e + "\n";
+			// log erroneous line and highlight offending character
+			err += "    L" + e.location.first_line + ": " + codeLine.substring(0, e.location.first_column) + offendingCharacter + codeLine.substring(e.location.first_column + 1) + "\n";
+			err += "         " + (new Array(e.location.first_column + 1).join(" ")) + "^\n";
+		}
+		throw new Error(err);
+	}
 	var map = JSON.parse(result.v3SourceMap);
 	map.sourcesContent = [source];
 	this.callback(null, result.js, map);

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 	MIT License http://www.opensource.org/licenses/mit-license.php
 	Author Tobias Koppers @sokra
 */
-var coffee = require("coffee-script");
+var coffee = require("coffeescript");
 var loaderUtils = require("loader-utils");
 module.exports = function(source) {
 	this.cacheable && this.cacheable();
@@ -24,8 +24,8 @@ module.exports = function(source) {
 	} catch (e) {
 		var err = "";
 		if (e.location == null || e.location.first_column == null || e.location.first_line == null) {
-			err += "Got an unexpected exception from the coffee-script compiler. The original exception was: " + e + "\n";
-			err += "(The coffee-script compiler should not raise *unexpected* exceptions. You can file this error as an issue of the coffee-script compiler: https://github.com/jashkenas/coffee-script/issues)\n";
+			err += "Got an unexpected exception from the coffeescript compiler. The original exception was: " + e + "\n";
+			err += "(The coffeescript compiler should not raise *unexpected* exceptions. You can file this error as an issue of the coffeescript compiler: https://github.com/jashkenas/coffee-script/issues)\n";
 		} else {
 			var codeLine = source.split("\n")[e.location.first_line];
 			var offendingCharacter = (e.location.first_column < codeLine.length) ? codeLine[e.location.first_column] : "";

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function(source) {
 	this.cacheable && this.cacheable();
 	var coffeeRequest = loaderUtils.getRemainingRequest(this);
 	var jsRequest = loaderUtils.getCurrentRequest(this);
-	var query = loaderUtils.parseQuery(this.query);
+	var query = loaderUtils.getOptions(this) || {};
 	var result;
 	try {
 		result = coffee.compile(source, {

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = function(source) {
 			filename: coffeeRequest,
 			debug: this.debug,
 			bare: true,
-			sourceMap: true,
+			sourceMap: query.sourceMap === undefined ? true : query.sourceMap,
 			sourceRoot: "",
 			sourceFiles: [coffeeRequest],
 			generatedFile: jsRequest
@@ -36,7 +36,11 @@ module.exports = function(source) {
 		}
 		throw new Error(err);
 	}
-	var map = JSON.parse(result.v3SourceMap);
-	map.sourcesContent = [source];
-	this.callback(null, result.js, map);
+	if (query.sourceMap) {
+		var map = JSON.parse(result.v3SourceMap);
+		map.sourcesContent = [source];
+		this.callback(null, result.js, map);
+	} else {
+		this.callback(null, result);
+	}
 }

--- a/index.js
+++ b/index.js
@@ -40,4 +40,3 @@ module.exports = function(source) {
 	map.sourcesContent = [source];
 	this.callback(null, result.js, map);
 }
-module.exports.seperable = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "coffee-loader",
-	"version": "0.7.1",
+	"version": "0.7.2",
 	"author": "Tobias Koppers @sokra",
 	"description": "coffee loader module for webpack",
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "coffee-loader",
-	"version": "0.7.2",
+	"version": "0.7.3",
 	"author": "Tobias Koppers @sokra",
 	"description": "coffee loader module for webpack",
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"loader-utils": "^1.0.2"
 	},
 	"peerDependencies": {
-		"coffee-script": "1.x"
+		"coffee-script": "^1.6.0"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"author": "Tobias Koppers @sokra",
 	"description": "coffee loader module for webpack",
 	"dependencies": {
-		"loader-utils": "0.2.x"
+		"loader-utils": "^1.0.2"
 	},
 	"peerDependencies": {
 		"coffee-script": "1.x"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 		"loader-utils": "^1.0.2"
 	},
 	"peerDependencies": {
-		"coffee-script": "^1.6.0"
+	    "coffeescript": ">= 1.8.x"
 	},
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "coffee-loader",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"author": "Tobias Koppers @sokra",
 	"description": "coffee loader module for webpack",
 	"dependencies": {


### PR DESCRIPTION
The loader previously ignored the `sourceMap` option passed in by the user, and always generated sourceMaps.  The documentation was incorrect as well (stating the default was `false`).