### PR TITLE
docs(README): remove `sourceMap` reference (`options.sourceMap`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ module.exports = {
 |Name|Default|Description|
 |:--:|:-----:|:----------|
 |**`literate`**|`false`|Enable CoffeeScript in Markdown (Code Blocks) e.g `file.coffee.md`|
-|**`sourceMap`**|`false`|Enable/Disable Sourcemaps|
 
 ### [Literate](http://coffeescript.org/#literate)
 
@@ -80,24 +79,7 @@ module.exports = {
 
 ### Sourcemaps
 
-**webpack.config.js**
-```js
-module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.coffee$/,
-        use: [
-          {
-            loader: 'coffee-loader',
-            options: { sourceMap: true }
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+Source maps are always produced.
 
 <h2 align="center">Maintainer</h2>
 


### PR DESCRIPTION
Fixes https://github.com/webpack-contrib/coffee-loader/issues/49 
 - Removes reference to `options.sourceMap` from the README, as it is actually not a valid option
